### PR TITLE
Added error prop without breaking changes to status flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "status-modal",
-  "version": "0.1.55",
+  "version": "0.1.57",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "status-modal",
-      "version": "0.1.55",
+      "version": "0.1.57",
       "license": "MIT",
       "dependencies": {
         "prop-types": "^15.8.1",

--- a/src/index.js
+++ b/src/index.js
@@ -4,11 +4,11 @@ import { BsCheck2All } from "react-icons/bs/";
 import { BiErrorCircle } from "react-icons/bi";
 import "./style/status.scss";
 
-const Status = ({ message, status }) => {
+const Status = ({ message, status, error }) => {
   return (
-    <div className={`default ${status === "error" && "error"}`}>
+    <div className={`default ${status === "error" || error ? "error" : ""}`}>
       <p>{message}</p>
-      {status !== "error" ? <BsCheck2All /> : <BiErrorCircle />}
+      {(status === "error" || error) ? <BiErrorCircle /> : <BsCheck2All /> } 
     </div>
   );
 };
@@ -16,6 +16,7 @@ const Status = ({ message, status }) => {
 propTypes.Status = {
   message: propTypes.string.isRequired,
   status: propTypes.string,
+  error: propTypes.bool,
 };
 
 export { Status };

--- a/src/style/status.scss
+++ b/src/style/status.scss
@@ -9,19 +9,32 @@
   animation: none;
 }
 
-.default {
+@mixin default ($status: "success") {
   width: 300px;
   height: 45px;
   display: flex;
   justify-content: space-between;
   position: absolute;
   background: ghostwhite;
-  border-bottom: 2px solid var(--success);
+  @if $status == "error" {
+    border-bottom: 2px solid var(--danger);
+    color: var(--danger);
+    margin-top: -40px;
+    svg {
+      color: var(--danger);
+    }
+  } @else {
+    border-bottom: 2px solid var(--success);
+    color: var(--success);
+    margin-top: 120px;
+    svg {
+      color: var(--success);
+    }
+  }
   box-shadow: 3px 1px 5px rgba(0, 0, 0, 0.11);
   font-weight: 500;
   border-radius: 3px;
   opacity: 0;
-  color: var(--success);
   padding-top: 5px;
   position: absolute;
   margin-top: 120px;
@@ -36,44 +49,18 @@
   }
 
   svg {
-    color: var(--success);
     font-size: 20px;
     font-weight: 500;
   }
 }
 
+.default {
+  @include default();
+}
+
 // error modal style
 .error {
-  width: 300px;
-  height: 45px;
-  display: flex;
-  justify-content: space-between;
-  position: absolute;
-  background: ghostwhite;
-  border-bottom: 2px solid var(--danger);
-  box-shadow: 3px 1px 5px rgba(0, 0, 0, 0.11);
-  font-weight: 500;
-  border-radius: 3px;
-  opacity: 0;
-  color: var(--danger);
-  padding-top: 5px;
-  position: absolute;
-  margin-top: -40px;
-  margin-left: 0px;
-  z-index: 10;
-  padding: 7px 8px;
-  animation: scaleModal 6s ease-in forwards;
-
-  p {
-    font-size: 15px;
-    font-weight: 600;
-  }
-
-  svg {
-    color: var(--danger);
-    font-size: 20px;
-    font-weight: 500;
-  }
+  @include default($status: "error");
 }
 
 // outline style


### PR DESCRIPTION
There were some duplicates in the styling between default and error, so I created a mixin that has styling common to the two classes and it can also take a status parameter to know when to style a css property (e.g border-bottom as error or default)